### PR TITLE
fix: return nil ptr on error and safeguard embedding nil ptrs in returns

### DIFF
--- a/sort_generic.go
+++ b/sort_generic.go
@@ -164,6 +164,7 @@ func Generic[E any](input <-chan E, fromBytes FromBytesGeneric[E], toBytes ToByt
 		s.mergeErrChan <- err
 		close(s.mergeErrChan)
 		close(s.mergeChunkChan)
+		return nil, s.mergeChunkChan, s.mergeErrChan
 	}
 	return s, s.mergeChunkChan, s.mergeErrChan
 }

--- a/sort_ordered.go
+++ b/sort_ordered.go
@@ -69,6 +69,9 @@ func (s *OrderedSorter[T]) toBytesOrdered(d T) ([]byte, error) {
 func Ordered[T cmp.Ordered](input <-chan T, config *Config) (*OrderedSorter[T], <-chan T, <-chan error) {
 	orderedSorter := newOrderedSorter[T]()
 	s, output, errChan := Generic(input, orderedSorter.fromBytesOrdered, orderedSorter.toBytesOrdered, cmp.Compare, config)
+	if s == nil {
+		return nil, output, errChan
+	}
 	orderedSorter.GenericSorter = *s
 	return orderedSorter, output, errChan
 }

--- a/sort_sorttype_legacy.go
+++ b/sort_sorttype_legacy.go
@@ -77,6 +77,10 @@ func New(input <-chan SortType, fromBytes FromBytes, lessFunc CompareLessFunc, c
 	compareGeneric := makeCompareSortType(lessFunc)
 
 	genericSorter, output, errChan := Generic(input, fromBytesGeneric, sortTypeToBytes, compareGeneric, config)
+	if genericSorter == nil {
+		return nil, output, errChan
+	}
+
 	s := &SortTypeSorter{GenericSorter: *genericSorter}
 	return s, output, errChan
 }

--- a/sort_strings.go
+++ b/sort_strings.go
@@ -28,6 +28,9 @@ func toBytesString(s string) ([]byte, error) {
 // This function provides backward compatibility with the legacy string-specific API.
 func Strings(input <-chan string, config *Config) (*StringSorter, <-chan string, <-chan error) {
 	genericSorter, output, errChan := Generic(input, fromBytesString, toBytesString, cmp.Compare, config)
+	if genericSorter == nil {
+		return nil, output, errChan
+	}
 	s := &StringSorter{GenericSorter: *genericSorter}
 	return s, output, errChan
 }


### PR DESCRIPTION
This is a rudimentary proposal for a fix of the issues outlined in #10:

`*GenericSorter[E]` with a `tempWriter` field of `nil` (due to initialization error) should not be returned as a non-nil pointer.
Consumers would assume a returned pointer to be a fully functional instance and run into panics (closed channels, nil-deref).

Instead, `nil` should be returned alongside the already closed channels and bubble up unmasked towards the last consumer.
Safeguards were put in place so that internal consumers (of generics) do not mask `nil` by embedding in return structs either.

I would not consider this to be an API break as previously returned non-functional pointers were unusuable.
The proposed changes returning `nil` aligns with common Go function return expectations in case of any errors.

The changes pass the test suite, but feel free to merge/close/critique as required.

fixes #10 